### PR TITLE
Remove final method modifier from getView

### DIFF
--- a/tableview/src/main/java/de/codecrafters/tableview/TableDataAdapter.java
+++ b/tableview/src/main/java/de/codecrafters/tableview/TableDataAdapter.java
@@ -145,7 +145,7 @@ public abstract class TableDataAdapter<T> extends ArrayAdapter<T> {
     public abstract View getCellView(int rowIndex, int columnIndex, ViewGroup parentView);
 
     @Override
-    public final View getView(final int rowIndex, final View convertView, final ViewGroup parent) {
+    public View getView(final int rowIndex, final View convertView, final ViewGroup parent) {
         final LinearLayout rowView = new LinearLayout(getContext());
 
         final AbsListView.LayoutParams rowLayoutParams = new AbsListView.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);


### PR DESCRIPTION
By removing the final modifier from getView, subclasses can override this method and provide a better implementation.

In the current implementation of TableDataAdapter, for each call to getView a new row is created. Then each row is populated with each call to getCellView in the implementating class. In the demo we can see how these cell views are also created each time. This is very inneficient and causes lag when scrolling long lists. 

In the future, a better implementation for the getView method would be desirable. It could be done using the ViewHolder idiom. However, by now I'd be just happy if the method were not final, so that I could override it in my subclass instead.
